### PR TITLE
add inverse_sqrt lr decay style

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -610,7 +610,7 @@ def _add_learning_rate_args(parser):
                        'and initial warmup, the learing rate at each '
                        'iteration would be different.')
     group.add_argument('--lr-decay-style', type=str, default='linear',
-                       choices=['constant', 'linear', 'cosine'],
+                       choices=['constant', 'linear', 'cosine', 'inverse_sqrt'],
                        help='Learning rate decay function.')
     group.add_argument('--lr-decay-iters', type=int, default=None,
                        help='number of iterations to decay learning rate over,'

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -621,6 +621,8 @@ def _add_learning_rate_args(parser):
     group.add_argument('--lr-decay-tokens', type=int, default=None,
                        help='number of tokens to decay learning rate over,'
                        ' If not None will override iter/sample-based decay')
+    group.add_argument('--lr-warmup-style', type=str, default='linear',
+                       choices=['constant', 'linear']),
     group.add_argument('--lr-warmup-fraction', type=float, default=None,
                        help='fraction of lr-warmup-(iters/samples) to use '
                        'for warmup (as a float)')

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -622,7 +622,8 @@ def _add_learning_rate_args(parser):
                        help='number of tokens to decay learning rate over,'
                        ' If not None will override iter/sample-based decay')
     group.add_argument('--lr-warmup-style', type=str, default='linear',
-                       choices=['constant', 'linear']),
+                       choices=['constant', 'linear'], help='Learning rate '
+                          'warmup function.')
     group.add_argument('--lr-warmup-fraction', type=float, default=None,
                        help='fraction of lr-warmup-(iters/samples) to use '
                        'for warmup (as a float)')

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -83,7 +83,8 @@ class AnnealingLR(object):
             return self.max_lr
 
         if self.decay_style == 'inverse_sqrt':
-            return self.max_lr / math.sqrt(max(self.num_steps - self.warmup_steps, 1))
+            num_steps_ = self.num_steps - self.warmup_steps
+            return self.max_lr / math.sqrt(max(num_steps_, 1))
 
         if self.decay_tokens is None:
             # step-based decay

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -68,6 +68,9 @@ class AnnealingLR(object):
             if self.num_steps == self.warmup_steps and \
                 self.decay_tokens is not None:
                 self.warmup_tokens = self.num_tokens
+            # if self.decay_style == 'inverse_sqrt':
+            #     # use constant warmup for inverse_sqrt
+                # return 1e-2
             return self.max_lr * float(self.num_steps) / \
                 float(self.warmup_steps)
 
@@ -102,6 +105,9 @@ class AnnealingLR(object):
             coeff = (1.0 - decay_ratio)
         elif self.decay_style == 'cosine':
             coeff = 0.5 * (math.cos(math.pi * decay_ratio) + 1.0)
+        elif self.decay_style == 'inverse_sqrt':
+            return self.max_lr * math.sqrt(float(self.warmup_steps)) / \
+                math.sqrt(float(num_steps_))
         else:
             raise Exception('{} decay style is not supported.'.format(
                 self.decay_style))

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -79,7 +79,7 @@ class AnnealingLR(object):
             return self.max_lr
 
         if self.decay_style == 'inverse_sqrt':
-            return self.max_lr / math.sqrt(float(max(num_steps_, 1)))
+            return self.max_lr / math.sqrt(max(num_steps_, 1))
 
         if self.decay_tokens is None:
             # step-based decay

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -78,6 +78,9 @@ class AnnealingLR(object):
         if self.decay_style == 'constant':
             return self.max_lr
 
+        if self.decay_style == 'inverse_sqrt':
+            return self.max_lr / math.sqrt(float(max(num_steps_, 1)))
+
         if self.decay_tokens is None:
             # step-based decay
             
@@ -105,8 +108,6 @@ class AnnealingLR(object):
             coeff = (1.0 - decay_ratio)
         elif self.decay_style == 'cosine':
             coeff = 0.5 * (math.cos(math.pi * decay_ratio) + 1.0)
-        elif self.decay_style == 'inverse_sqrt':
-            return self.max_lr / math.sqrt(float(max(num_steps_, 1)))
         else:
             raise Exception('{} decay style is not supported.'.format(
                 self.decay_style))

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -64,6 +64,19 @@ class AnnealingLR(object):
         """Learning rate decay functions from:
               https://openreview.net/pdf?id=BJYwwY9ll pg. 4"""
 
+
+        if self.decay_style == 'inverse_sqrt':
+            if self.warmup_steps > 0 and self.num_steps <= self.warmup_steps:
+                if self.warmup_style == 'linear':
+                    return self.max_lr * self.num_steps / (self.warmup_steps * self.warmup_steps**0.5)
+                elif self.warmup_style == 'constant':
+                    return self.max_lr / self.warmup_steps**0.5
+                else:
+                    raise ValueError('Unknown warmup style: {}'.format(
+                        self.warmup_style))
+                
+            return self.max_lr / (max(self.num_steps, 1))**0.5
+
         # Use warmup for the initial part.
         if self.warmup_steps > 0 and self.num_steps <= self.warmup_steps:
             if self.num_steps == self.warmup_steps and \
@@ -82,9 +95,6 @@ class AnnealingLR(object):
         if self.decay_style == 'constant':
             return self.max_lr
 
-        if self.decay_style == 'inverse_sqrt':
-            num_steps_ = self.num_steps - self.warmup_steps
-            return self.max_lr / math.sqrt(max(num_steps_, 1))
 
         if self.decay_tokens is None:
             # step-based decay

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -106,8 +106,7 @@ class AnnealingLR(object):
         elif self.decay_style == 'cosine':
             coeff = 0.5 * (math.cos(math.pi * decay_ratio) + 1.0)
         elif self.decay_style == 'inverse_sqrt':
-            return self.max_lr * math.sqrt(float(max(self.warmup_steps, 1))) / \
-                math.sqrt(float(max(num_steps_,1)))
+            return self.max_lr / math.sqrt(float(max(num_steps_, 1)))
         else:
             raise Exception('{} decay style is not supported.'.format(
                 self.decay_style))

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -65,18 +65,6 @@ class AnnealingLR(object):
               https://openreview.net/pdf?id=BJYwwY9ll pg. 4"""
 
 
-        if self.decay_style == 'inverse_sqrt':
-            if self.warmup_steps > 0 and self.num_steps <= self.warmup_steps:
-                if self.warmup_style == 'linear':
-                    return self.max_lr * self.num_steps / (self.warmup_steps * self.warmup_steps**0.5)
-                elif self.warmup_style == 'constant':
-                    return self.max_lr / self.warmup_steps**0.5
-                else:
-                    raise ValueError('Unknown warmup style: {}'.format(
-                        self.warmup_style))
-                
-            return self.max_lr / (max(self.num_steps, 1))**0.5
-
         # Use warmup for the initial part.
         if self.warmup_steps > 0 and self.num_steps <= self.warmup_steps:
             if self.num_steps == self.warmup_steps and \
@@ -95,6 +83,12 @@ class AnnealingLR(object):
         if self.decay_style == 'constant':
             return self.max_lr
 
+
+        # If linear
+        # In warmup phase: lr = max_lr
+        # In decay phase: lr = max_lr * sqrt(warmup_steps) / sqrt(num_steps)
+        if self.decay_style == 'inverse_sqrt':
+            return self.max_lr * (max(self.warmup_steps, 1) / max(self.num_steps, 1))**0.5
 
         if self.decay_tokens is None:
             # step-based decay

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -87,6 +87,7 @@ class AnnealingLR(object):
         # If constant decay style
         # In warmup phase: lr = max_lr
         # In decay phase: lr = max_lr * sqrt(warmup_steps) / sqrt(num_steps)
+        # Note: To replicate t5x check https://github.com/TurkuNLP/Megatron-DeepSpeed/pull/2
         if self.decay_style == 'inverse_sqrt':
             return self.max_lr * (max(self.warmup_steps, 1) / max(self.num_steps, 1))**0.5
 

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -106,8 +106,8 @@ class AnnealingLR(object):
         elif self.decay_style == 'cosine':
             coeff = 0.5 * (math.cos(math.pi * decay_ratio) + 1.0)
         elif self.decay_style == 'inverse_sqrt':
-            return self.max_lr * math.sqrt(float(self.warmup_steps)) / \
-                math.sqrt(float(num_steps_))
+            return self.max_lr * math.sqrt(float(max(self.warmup_steps, 1))) / \
+                math.sqrt(float(max(num_steps_,1)))
         else:
             raise Exception('{} decay style is not supported.'.format(
                 self.decay_style))

--- a/megatron/learning_rates.py
+++ b/megatron/learning_rates.py
@@ -84,7 +84,7 @@ class AnnealingLR(object):
             return self.max_lr
 
 
-        # If linear
+        # If constant decay style
         # In warmup phase: lr = max_lr
         # In decay phase: lr = max_lr * sqrt(warmup_steps) / sqrt(num_steps)
         if self.decay_style == 'inverse_sqrt':

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -361,6 +361,7 @@ def get_learning_rate_scheduler(optimizer):
         warmup_steps=warmup_steps,
         decay_steps=decay_steps,
         decay_style=args.lr_decay_style,
+        warmup_style=args.lr_warmup_style,
         use_checkpoint_lr_scheduler=args.use_checkpoint_lr_scheduler,
         override_lr_scheduler=args.override_lr_scheduler)
 


### PR DESCRIPTION
adds support for inverse square decay style
P.S: ignores `min-lr` param for now

To use it just add these flags to your command:
```
--lr-decay-style=inverse_sqrt --lr-warmup-style=linear/constant
```

![image](https://user-images.githubusercontent.com/29777165/203429204-c5e0e7d4-798f-445b-b561-9363122efa60.png)
